### PR TITLE
feat: ajout des CGU en français dans /assets/data/cgu-fr.json pour exploitation directe

### DIFF
--- a/assets/data/cgu-fr.json
+++ b/assets/data/cgu-fr.json
@@ -1,0 +1,67 @@
+{
+  "title": "Conditions Générales d'Utilisation (CGU)",
+  "version": "1.1",
+  "lastUpdate": "20/05/2025",
+  "content": [
+    {
+      "heading": "1. Objet",
+      "body": "Les présentes Conditions Générales d’Utilisation (CGU) ont pour objet de définir les modalités d’accès et d’utilisation de l’application mobile Moove It (ci-après « l’Application ») dédiée à la pratique sportive, au suivi de la progression, à la gamification et à la mise en relation d’utilisateurs autour de sports comme la natation ou le padel."
+    },
+    {
+      "heading": "2. Acceptation des CGU",
+      "body": "L’inscription et l’utilisation de l’Application impliquent l’acceptation pleine et entière des présentes CGU. Si tu refuses tout ou partie de ces conditions, tu ne dois pas utiliser l’Application."
+    },
+    {
+      "heading": "3. Inscription et Compte Utilisateur",
+      "body": "Pour utiliser l’Application, tu dois créer un compte en renseignant des informations exactes et à jour. Tu t’engages à ne pas usurper l’identité d’un tiers. Le mot de passe est personnel et confidentiel ; tu es responsable de toute activité liée à ton compte."
+    },
+    {
+      "heading": "4. Utilisation de l’Application",
+      "body": "Tu t’engages à utiliser l’Application dans le respect des lois et règlements en vigueur et à ne pas porter atteinte à la sécurité ou à l’intégrité du service, ni à l’expérience des autres utilisateurs."
+    },
+    {
+      "heading": "5. Données Personnelles et Confidentialité",
+      "body": "Moove It collecte et traite certaines de tes données (identité, progrès, récompenses, statistiques) dans le respect du RGPD et uniquement pour le fonctionnement de l’Application. Aucune donnée n’est cédée ou vendue à des tiers sans ton consentement. Tu peux exercer tes droits d’accès, de rectification, de suppression et d’opposition à tout moment en nous contactant."
+    },
+    {
+      "heading": "6. Sécurité des Données",
+      "body": "Nous mettons en œuvre toutes les mesures raisonnables pour protéger tes données. Cependant, la sécurité absolue n’existe pas : tu restes responsable de la confidentialité de tes accès et de la sécurité de ton appareil."
+    },
+    {
+      "heading": "7. Propriété Intellectuelle",
+      "body": "Les contenus de l’Application (textes, images, logos, icônes, médailles, interface, code) sont protégés par le droit d’auteur et restent la propriété exclusive de Moove It ou de ses partenaires. Toute reproduction ou utilisation sans autorisation préalable est interdite."
+    },
+    {
+      "heading": "8. Contenus Utilisateurs",
+      "body": "Tu peux être amené à publier des contenus (photos, commentaires, progression). Tu restes propriétaire de ces contenus mais autorises Moove It à les utiliser dans le cadre du fonctionnement et de la promotion de l’Application, dans le respect de ta vie privée."
+    },
+    {
+      "heading": "9. Modération et Signalement",
+      "body": "Tout contenu ou comportement inapproprié, offensant, frauduleux ou contraire à l’esprit sportif pourra être signalé et entraîner la suspension ou la suppression du compte, sans préavis."
+    },
+    {
+      "heading": "10. Responsabilité",
+      "body": "Moove It n’est pas responsable des dommages directs ou indirects résultant de l’utilisation de l’Application, ni des pertes de données, ni de l’inexactitude des informations fournies par les utilisateurs. L’Application ne remplace pas l’avis médical professionnel pour la pratique sportive."
+    },
+    {
+      "heading": "11. Disponibilité du Service",
+      "body": "Nous faisons tout notre possible pour garantir l’accessibilité et la qualité du service, mais ne pouvons garantir une disponibilité sans interruption. Moove It se réserve le droit de modifier, suspendre ou interrompre l’Application à tout moment, sans préavis."
+    },
+    {
+      "heading": "12. Modification des CGU",
+      "body": "Les CGU peuvent être modifiées à tout moment. Toute modification substantielle fera l’objet d’une information spécifique (notification, email…). L’utilisation continue de l’Application après modification vaut acceptation des nouvelles CGU."
+    },
+    {
+      "heading": "13. Durée et Résiliation",
+      "body": "Les CGU s’appliquent pendant toute la durée d’utilisation de l’Application. Tu peux résilier ton compte à tout moment en nous contactant. Moove It peut également suspendre ou supprimer un compte en cas de non-respect des CGU."
+    },
+    {
+      "heading": "14. Droit Applicable",
+      "body": "Les présentes CGU sont soumises au droit français. Tout litige sera soumis à la compétence exclusive des tribunaux français."
+    },
+    {
+      "heading": "15. Contact",
+      "body": "Pour toute question, demande relative à tes données personnelles ou signalement, contacte-nous à support@mooveit.app."
+    }
+  ]
+}


### PR DESCRIPTION
création du fichier FRONT assets/data/cgu-fr.json permettant de servir le screen CGU :

💻Pratique courante de mettre ce type de fichier statique directement dans les ressources du front pour exploitation directe.
↗️Evolution possible avec plusieurs langues (cgu-en, cgu-it, cgu-es...etc..)
📁 Fichier structuré de façon à pouvoir exploiter une mise en page titres / paragraphes.

Merci de votre lecture et de votre approbation 🚀